### PR TITLE
Add exemplar tags

### DIFF
--- a/library_schemas/slam/prerelease/HED_slam_1.0.0.mediawiki
+++ b/library_schemas/slam/prerelease/HED_slam_1.0.0.mediawiki
@@ -6,6 +6,17 @@ The HED SLAM(Sensor Location and Motion) HED library schema is designed to stand
 !# start schema
 
 '''Anatomical-landmark''' <nowiki>{rooted=Anatomical-item} [A collection of specific points on the human body used for anatomical and sensor placement reference.]</nowiki>
+* Head-landmark <nowiki>[Points on the head used as reference landmarks.]</nowiki>
+** Inion <nowiki>[The most prominent point of the occipital bone at the back of the head.]</nowiki>
+** Left-helix-tragus-junction-LHJ <nowiki>[The point where the helix meets the tragus of the left ear.]</nowiki>
+** Mastoid-process
+** Nasion <nowiki>[The midpoint between the eyes just above the bridge of the nose.]</nowiki>
+** Right-helix-tragus-junction-RHJ <nowiki>[The point where the helix meets the tragus of the right ear.]</nowiki>
+** Vertex <nowiki>[The highest point on the head in the midline.]</nowiki>
+* Torso-chest-landmark <nowiki>[Points on the chest used as reference landmarks.]</nowiki>
+** Acromion-process <nowiki>[The outermost point of the shoulder blade.]</nowiki>
+** Vertebra-prominens-C7 <nowiki>[The seventh cervical vertebra at the base of the neck.]</nowiki>
+** Xiphoid-process <nowiki>[The small cartilaginous process at the lower end of the sternum.]</nowiki>
 
 
 !# end schema

--- a/library_schemas/slam/prerelease/HED_slam_1.0.0.xml
+++ b/library_schemas/slam/prerelease/HED_slam_1.0.0.xml
@@ -1512,6 +1512,93 @@
                      <name>inLibrary</name>
                      <value>slam</value>
                   </attribute>
+                  <node>
+                     <name>Head-landmark</name>
+                     <description>Points on the head used as reference landmarks.</description>
+                     <attribute>
+                        <name>inLibrary</name>
+                        <value>slam</value>
+                     </attribute>
+                     <node>
+                        <name>Inion</name>
+                        <description>The most prominent point of the occipital bone at the back of the head.</description>
+                        <attribute>
+                           <name>inLibrary</name>
+                           <value>slam</value>
+                        </attribute>
+                     </node>
+                     <node>
+                        <name>Left-helix-tragus-junction-LHJ</name>
+                        <description>The point where the helix meets the tragus of the left ear.</description>
+                        <attribute>
+                           <name>inLibrary</name>
+                           <value>slam</value>
+                        </attribute>
+                     </node>
+                     <node>
+                        <name>Mastoid-process</name>
+                        <attribute>
+                           <name>inLibrary</name>
+                           <value>slam</value>
+                        </attribute>
+                     </node>
+                     <node>
+                        <name>Nasion</name>
+                        <description>The midpoint between the eyes just above the bridge of the nose.</description>
+                        <attribute>
+                           <name>inLibrary</name>
+                           <value>slam</value>
+                        </attribute>
+                     </node>
+                     <node>
+                        <name>Right-helix-tragus-junction-RHJ</name>
+                        <description>The point where the helix meets the tragus of the right ear.</description>
+                        <attribute>
+                           <name>inLibrary</name>
+                           <value>slam</value>
+                        </attribute>
+                     </node>
+                     <node>
+                        <name>Vertex</name>
+                        <description>The highest point on the head in the midline.</description>
+                        <attribute>
+                           <name>inLibrary</name>
+                           <value>slam</value>
+                        </attribute>
+                     </node>
+                  </node>
+                  <node>
+                     <name>Torso-chest-landmark</name>
+                     <description>Points on the chest used as reference landmarks.</description>
+                     <attribute>
+                        <name>inLibrary</name>
+                        <value>slam</value>
+                     </attribute>
+                     <node>
+                        <name>Acromion-process</name>
+                        <description>The outermost point of the shoulder blade.</description>
+                        <attribute>
+                           <name>inLibrary</name>
+                           <value>slam</value>
+                        </attribute>
+                     </node>
+                     <node>
+                        <name>Vertebra-prominens-C7</name>
+                        <description>The seventh cervical vertebra at the base of the neck.</description>
+                        <attribute>
+                           <name>inLibrary</name>
+                           <value>slam</value>
+                        </attribute>
+                     </node>
+                     <node>
+                        <name>Xiphoid-process</name>
+                        <description>The small cartilaginous process at the lower end of the sternum.</description>
+                        <attribute>
+                           <name>inLibrary</name>
+                           <value>slam</value>
+                        </attribute>
+                     </node>
+                  </node>
                </node>
                <node>
                   <name>Body</name>

--- a/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_AnnotationPropertyExternal.tsv
+++ b/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_AnnotationPropertyExternal.tsv
@@ -14,3 +14,4 @@ dc:	title
 dc:	type
 foaf:	homepage
 terms:	license
+obo:	has_dbxref

--- a/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Prefixes.tsv
+++ b/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Prefixes.tsv
@@ -9,4 +9,3 @@ dc:	http://purl.org/dc/elements/1.1/	The Dublin Core elements
 terms:	http://purl.org/dc/terms/	The Dublin Core terms
 foaf:	http://xmlns.com/foaf/0.1/	Friend-of-a-Friend http://xmlns.com/foaf/spec/
 obo:	http://purl.obolibrary.org/obo/	Open Biomedical Ontologies
-has_dbxref:	http://www.geneontology.org/formats/oboInOwl#dbxref	Relates an entity to an external database entry

--- a/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Prefixes.tsv
+++ b/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Prefixes.tsv
@@ -8,3 +8,4 @@ prov:	http://www.w3.org/ns/prov#	The PROV namespace [PROV-DM]
 dc:	http://purl.org/dc/elements/1.1/	The Dublin Core elements
 terms:	http://purl.org/dc/terms/	The Dublin Core terms
 foaf:	http://xmlns.com/foaf/0.1/	Friend-of-a-Friend http://xmlns.com/foaf/spec/
+has_dbxref	http://www.geneontology.org/formats/oboInOwl#dbxref	Relates an entity to an external database entry

--- a/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Prefixes.tsv
+++ b/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Prefixes.tsv
@@ -8,4 +8,5 @@ prov:	http://www.w3.org/ns/prov#	The PROV namespace [PROV-DM]
 dc:	http://purl.org/dc/elements/1.1/	The Dublin Core elements
 terms:	http://purl.org/dc/terms/	The Dublin Core terms
 foaf:	http://xmlns.com/foaf/0.1/	Friend-of-a-Friend http://xmlns.com/foaf/spec/
-has_dbxref	http://www.geneontology.org/formats/oboInOwl#dbxref	Relates an entity to an external database entry
+obo:	http://purl.obolibrary.org/obo/	Open Biomedical Ontologies
+has_dbxref:	http://www.geneontology.org/formats/oboInOwl#dbxref	Relates an entity to an external database entry

--- a/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
+++ b/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
@@ -1,2 +1,13 @@
 hedId	rdfs:label	Level	omn:SubClassOf	Attributes	dc:description	omn:EquivalentTo	Annotations
-	Anatomical-landmark	0	Anatomical-item	rooted=Anatomical-item	A collection of specific points on the human body used for anatomical and sensor placement reference.		dc:source "Original", rdfs:comment "Body landmarks are used to standardize sensor placement."
+	Anatomical-landmark	0	Anatomical-item	rooted=Anatomical-item	A collection of specific points on the human body used for anatomical and sensor placement reference.		dc:source "Original", rdfs:comment "Body landmarks are used to standardize sensor placement.
+	Head-landmark	1	Anatomical-landmarks		Points on the head used as reference landmarks.		dc:source "Original"
+	Nasion	2	Head-landmark		The midpoint between the eyes just above the bridge of the nose.		
+	Inion	2	Head-landmark		The most prominent point of the occipital bone at the back of the head.		
+	Left Helix-Tragus Junction (LHJ)	2	Head-landmark		The point where the helix meets the tragus of the left ear.		
+	Right Helix-Tragus Junction (RHJ)	2	Head-landmark		The point where the helix meets the tragus of the right ear.		
+	Vertex	2	Head-landmark		The highest point on the head in the midline.		
+	Mastoid-process	2	Head-landmark				dc:source "Original"
+	Torso-chest-landmark	1	Anatomical-landmarks		Points on the chest used as reference landmarks.		dc:source "Original"
+	Acromion-process	2	Torso-chest-landmark		The outermost point of the shoulder blade.		has_dbxref: "NCIT:C32048" "FMA:12525" "UBERON:0002497"
+	Vertebra-prominens (C7)	2	Torso-chest-landmark		The seventh cervical vertebra at the base of the neck.		has_dbxref: "NCIT:C32245" "FMA:23260" "UBERON:0004616"
+	Xiphoid-process	2	Torso-chest-landmark		The small cartilaginous process at the lower end of the sternum.		has_dbxref: "NCIT:C33895" "FMA:7488" "UBERON:0002207"

--- a/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
+++ b/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
@@ -1,12 +1,12 @@
 hedId	rdfs:label	Level	omn:SubClassOf	Attributes	dc:description	omn:EquivalentTo	Annotations
 	Anatomical-landmark	0	Anatomical-item	rooted=Anatomical-item	A collection of specific points on the human body used for anatomical and sensor placement reference.		dc:source "Original", rdfs:comment "Body landmarks are used to standardize sensor placement.
 	Head-landmark	1	Anatomical-landmark		Points on the head used as reference landmarks.		dc:source "Original"
-	Nasion	2	Head-landmark		The midpoint between the eyes just above the bridge of the nose.		
 	Inion	2	Head-landmark		The most prominent point of the occipital bone at the back of the head.		
 	Left-helix-tragus-junction-LHJ	2	Head-landmark		The point where the helix meets the tragus of the left ear.		
+	Mastoid-process	2	Head-landmark				dc:source "Original"
+	Nasion	2	Head-landmark		The midpoint between the eyes just above the bridge of the nose.		
 	Right-helix-tragus-junction-RHJ	2	Head-landmark		The point where the helix meets the tragus of the right ear.		
 	Vertex	2	Head-landmark		The highest point on the head in the midline.		
-	Mastoid-process	2	Head-landmark				dc:source "Original"
 	Torso-chest-landmark	1	Anatomical-landmark		Points on the chest used as reference landmarks.		dc:source "Original"
 	Acromion-process	2	Torso-chest-landmark		The outermost point of the shoulder blade.		obo:has_dbxref "NCIT:C32048", obo:has_dbxref "FMA:12525", obo:has_dbxref "UBERON:0002497"
 	Vertebra-prominens-C7	2	Torso-chest-landmark		The seventh cervical vertebra at the base of the neck.		obo:has_dbxref "NCIT:C32245", obo:has_dbxref "FMA:23260", obo:has_dbxref "UBERON:0004616"

--- a/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
+++ b/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
@@ -7,7 +7,7 @@ hedId	rdfs:label	Level	omn:SubClassOf	Attributes	dc:description	omn:EquivalentTo
 	Right-helix-tragus-junction-RHJ	2	Head-landmark		The point where the helix meets the tragus of the right ear.		
 	Vertex	2	Head-landmark		The highest point on the head in the midline.		
 	Mastoid-process	2	Head-landmark				dc:source "Original"
-	Torso-chest-landmark	1	Anatomical-landmarks		Points on the chest used as reference landmarks.		dc:source "Original"
+	Torso-chest-landmark	1	Anatomical-landmark		Points on the chest used as reference landmarks.		dc:source "Original"
 	Acromion-process	2	Torso-chest-landmark		The outermost point of the shoulder blade.		obo:has_dbxref "NCIT:C32048", obo:has_dbxref "FMA:12525", obo:has_dbxref "UBERON:0002497"
 	Vertebra-prominens-C7	2	Torso-chest-landmark		The seventh cervical vertebra at the base of the neck.		obo:has_dbxref "NCIT:C32245", obo:has_dbxref "FMA:23260", obo:has_dbxref "UBERON:0004616"
 	Xiphoid-process	2	Torso-chest-landmark		The small cartilaginous process at the lower end of the sternum.		obo:has_dbxref "NCIT:C33895", obo:has_dbxref "FMA:7488", obo:has_dbxref "UBERON:0002207"

--- a/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
+++ b/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
@@ -1,13 +1,13 @@
 hedId	rdfs:label	Level	omn:SubClassOf	Attributes	dc:description	omn:EquivalentTo	Annotations
 	Anatomical-landmark	0	Anatomical-item	rooted=Anatomical-item	A collection of specific points on the human body used for anatomical and sensor placement reference.		dc:source "Original", rdfs:comment "Body landmarks are used to standardize sensor placement.
-	Head-landmark	1	Anatomical-landmarks		Points on the head used as reference landmarks.		dc:source "Original"
+	Head-landmark	1	Anatomical-landmark		Points on the head used as reference landmarks.		dc:source "Original"
 	Nasion	2	Head-landmark		The midpoint between the eyes just above the bridge of the nose.		
 	Inion	2	Head-landmark		The most prominent point of the occipital bone at the back of the head.		
-	Left Helix-Tragus Junction (LHJ)	2	Head-landmark		The point where the helix meets the tragus of the left ear.		
-	Right Helix-Tragus Junction (RHJ)	2	Head-landmark		The point where the helix meets the tragus of the right ear.		
+	Left-helix-tragus-junction-LHJ	2	Head-landmark		The point where the helix meets the tragus of the left ear.		
+	Right-helix-tragus-junction-RHJ	2	Head-landmark		The point where the helix meets the tragus of the right ear.		
 	Vertex	2	Head-landmark		The highest point on the head in the midline.		
 	Mastoid-process	2	Head-landmark				dc:source "Original"
 	Torso-chest-landmark	1	Anatomical-landmarks		Points on the chest used as reference landmarks.		dc:source "Original"
 	Acromion-process	2	Torso-chest-landmark		The outermost point of the shoulder blade.		obo:has_dbxref "NCIT:C32048", obo:has_dbxref "FMA:12525", obo:has_dbxref "UBERON:0002497"
-	Vertebra-prominens (C7)	2	Torso-chest-landmark		The seventh cervical vertebra at the base of the neck.		obo:has_dbxref "NCIT:C32245", obo:has_dbxref "FMA:23260", obo:has_dbxref "UBERON:0004616"
+	Vertebra-prominens-C7	2	Torso-chest-landmark		The seventh cervical vertebra at the base of the neck.		obo:has_dbxref "NCIT:C32245", obo:has_dbxref "FMA:23260", obo:has_dbxref "UBERON:0004616"
 	Xiphoid-process	2	Torso-chest-landmark		The small cartilaginous process at the lower end of the sternum.		obo:has_dbxref "NCIT:C33895", obo:has_dbxref "FMA:7488", obo:has_dbxref "UBERON:0002207"

--- a/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
+++ b/library_schemas/slam/prerelease/hedtsv/HED_slam_1.0.0/HED_slam_1.0.0_Tag.tsv
@@ -8,6 +8,6 @@ hedId	rdfs:label	Level	omn:SubClassOf	Attributes	dc:description	omn:EquivalentTo
 	Vertex	2	Head-landmark		The highest point on the head in the midline.		
 	Mastoid-process	2	Head-landmark				dc:source "Original"
 	Torso-chest-landmark	1	Anatomical-landmarks		Points on the chest used as reference landmarks.		dc:source "Original"
-	Acromion-process	2	Torso-chest-landmark		The outermost point of the shoulder blade.		has_dbxref: "NCIT:C32048" "FMA:12525" "UBERON:0002497"
-	Vertebra-prominens (C7)	2	Torso-chest-landmark		The seventh cervical vertebra at the base of the neck.		has_dbxref: "NCIT:C32245" "FMA:23260" "UBERON:0004616"
-	Xiphoid-process	2	Torso-chest-landmark		The small cartilaginous process at the lower end of the sternum.		has_dbxref: "NCIT:C33895" "FMA:7488" "UBERON:0002207"
+	Acromion-process	2	Torso-chest-landmark		The outermost point of the shoulder blade.		obo:has_dbxref "NCIT:C32048", obo:has_dbxref "FMA:12525", obo:has_dbxref "UBERON:0002497"
+	Vertebra-prominens (C7)	2	Torso-chest-landmark		The seventh cervical vertebra at the base of the neck.		obo:has_dbxref "NCIT:C32245", obo:has_dbxref "FMA:23260", obo:has_dbxref "UBERON:0004616"
+	Xiphoid-process	2	Torso-chest-landmark		The small cartilaginous process at the lower end of the sternum.		obo:has_dbxref "NCIT:C33895", obo:has_dbxref "FMA:7488", obo:has_dbxref "UBERON:0002207"


### PR DESCRIPTION
I have added a couple of tags with references in the Annotation column.
I think there are some outstanding points:
1. Should the database names also defined in the prefixes (I assume not, because the names are already available in OBO)
2. Should we use `has_dbxref` or `db_xref` for cross-referencing (or any other label)? `has_dbxref` is defined [here](http://www.geneontology.org/formats/oboInOwl#dbxref) and `db_xref` is defined [here](https://www.ncbi.nlm.nih.gov/genbank/collab/db_xref/).
3. What should I do for the abbreviations, like `LHJ` and `RHJ`? Many of them are quite well-known and handy to use